### PR TITLE
fix(android): map null values by checking JSONObject.NULL

### DIFF
--- a/android/src/main/java/io/ionic/portals/reactnative/ReactNativePortalManager.kt
+++ b/android/src/main/java/io/ionic/portals/reactnative/ReactNativePortalManager.kt
@@ -182,7 +182,7 @@ internal fun JSONObject.toReactMap(): ReadableMap =
                 is Int -> map.putInt(key, value)
                 is Double -> map.putDouble(key, value)
                 is String -> map.putString(key, value)
-                JSONObject.NULL -> map.putNull(key)
+                null, JSONObject.NULL -> map.putNull(key)
                 else -> map.putString(key, value.toString())
             }
         } catch (_: JSONException) {
@@ -201,7 +201,7 @@ private fun JSONArray.toReactArray(): ReadableArray =
                 is Int -> array.pushInt(value)
                 is Double -> array.pushDouble(value)
                 is String -> array.pushString(value)
-                JSONObject.NULL -> array.pushNull()
+                null, JSONObject.NULL -> array.pushNull()
                 else -> array.pushString(value.toString())
             }
         } catch (_: JSONException) {

--- a/android/src/main/java/io/ionic/portals/reactnative/ReactNativePortalManager.kt
+++ b/android/src/main/java/io/ionic/portals/reactnative/ReactNativePortalManager.kt
@@ -182,7 +182,7 @@ internal fun JSONObject.toReactMap(): ReadableMap =
                 is Int -> map.putInt(key, value)
                 is Double -> map.putDouble(key, value)
                 is String -> map.putString(key, value)
-                null -> map.putNull(key)
+                JSONObject.NULL -> map.putNull(key)
                 else -> map.putString(key, value.toString())
             }
         } catch (_: JSONException) {
@@ -201,7 +201,7 @@ private fun JSONArray.toReactArray(): ReadableArray =
                 is Int -> array.pushInt(value)
                 is Double -> array.pushDouble(value)
                 is String -> array.pushString(value)
-                null -> array.pushNull()
+                JSONObject.NULL -> array.pushNull()
                 else -> array.pushString(value.toString())
             }
         } catch (_: JSONException) {


### PR DESCRIPTION
Replace instances of `null -> map.putNull(key)` with `JSONObject.NULL -> map.putNull(key)`. 

This will properly return `null` back to React Native instead of the string value`'null'`. 

I tested this (locally) against [this repro](https://github.com/eric-horodyski/portals-react-native-android-null-issue) to ensure it worked.