### PR TITLE
fix(android): added override on receiveCommand that supports an ID of type Int

### DIFF
--- a/android/src/main/java/io/ionic/portals/reactnative/PortalView.kt
+++ b/android/src/main/java/io/ionic/portals/reactnative/PortalView.kt
@@ -49,6 +49,16 @@ internal class PortalViewManager(private val context: ReactApplicationContext) :
         return mutableMapOf("create" to createId)
     }
 
+    @Deprecated("Deprecated, but using to support New Architecture")
+    override fun receiveCommand(root: FrameLayout, commandId: Int, args: ReadableArray?) {
+        super.receiveCommand(root, commandId, args)
+        val viewId = args?.getInt(0) ?: return
+
+        when (commandId) {
+            createId -> createFragment(root, viewId)
+        }
+    }
+
     override fun receiveCommand(root: FrameLayout, commandId: String?, args: ReadableArray?) {
         super.receiveCommand(root, commandId, args)
         val viewId = args?.getInt(0) ?: return


### PR DESCRIPTION
This fixes an issue where Portals for RN in Android would not function if the `newArchEnabled` flag was set to `true`